### PR TITLE
Add --namespace argument to deploy populator in another namespace

### DIFF
--- a/example/hello-populator/main.go
+++ b/example/hello-populator/main.go
@@ -31,7 +31,6 @@ import (
 )
 
 const (
-	namespace  = "hello"
 	prefix     = "hello.k8s.io"
 	mountPath  = "/mnt"
 	devicePath = "/dev/block"
@@ -48,6 +47,7 @@ func main() {
 		kubeconfig   string
 		imageName    string
 		showVersion  bool
+		namespace    string
 	)
 	// Main arg
 	flag.StringVar(&mode, "mode", "", "Mode to run in (controller, populate)")
@@ -59,6 +59,7 @@ func main() {
 	flag.StringVar(&masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&imageName, "image-name", "", "Image to use for populating")
 	flag.BoolVar(&showVersion, "version", false, "display the version string")
+	flag.StringVar(&namespace, "namespace", "hello", "Namespace to deploy controller")
 	flag.Parse()
 
 	if showVersion {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Add --namespace argument to deploy populator in another namespace

**Which issue(s) this PR fixes**:
Fixes #16 

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:
```release-note
hello-populator: add --namespace flag to the hello-populator example to deploy in another namespace.
```
