### PR TITLE
hello-populator: update deploy.yaml to use published v0.1.0 image

### DIFF
--- a/example/hello-populator/README.md
+++ b/example/hello-populator/README.md
@@ -8,21 +8,6 @@ This example demonstrates an extremely simple populator implementation.
 Install kubernetes 1.17 or later, and enable the AnyVolumeDataSource
 feature gate.
 
-Build the image from code:
-
-`make all`
-
-Make sure you have a repo you can push to, and set the variable
-
-`YOUR_REPO=...`
-
-Push the image to your repo:
-
-```
-docker tag hello-populator:latest ${YOUR_REPO}/hello-populator:latest
-docker push ${YOUR_REPO}/hello-populator:latest
-```
-
 Install the CRD:
 
 `kubectl apply -f crd.yaml`
@@ -101,3 +86,20 @@ Wait for the job to complete:
 Get the logs from the job to verify that it worked:
 
 `kubectl logs job/job1`
+
+### To build the image from code:
+
+`make all`
+
+Make sure you have a repo you can push to, and set the variable
+
+`YOUR_REPO=...`
+
+Push the image to your repo:
+
+```
+docker tag hello-populator:latest ${YOUR_REPO}/hello-populator:latest
+docker push ${YOUR_REPO}/hello-populator:latest
+```
+
+To use the image, update deploy.yaml before installing the controller.

--- a/example/hello-populator/deploy.yaml
+++ b/example/hello-populator/deploy.yaml
@@ -61,11 +61,11 @@ spec:
       serviceAccount: hello-account
       containers:
         - name: hello
-          image: hello-populator:latest
+          image: k8s.gcr.io/sig-storage/hello-populator:v0.1.0
           imagePullPolicy: IfNotPresent
           args:
             - --mode=controller
-            - --image-name=hello-populator:latest
+            - --image-name=k8s.gcr.io/sig-storage/hello-populator:v0.1.0
 ---
 kind: VolumePopulator
 apiVersion: populator.storage.k8s.io/v1alpha1


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
For users to test steps described in https://kubernetes.io/blog/2021/08/30/volume-populators-redesigned/#putting-it-all-together , published image should be used for hello-populator.

**Which issue(s) this PR fixes**:
Fixes #15 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
