### PR TITLE
Use v1beta1 of the VolumePopulator API

### DIFF
--- a/example/hello-populator/deploy.yaml
+++ b/example/hello-populator/deploy.yaml
@@ -73,7 +73,7 @@ spec:
               protocol: TCP
 ---
 kind: VolumePopulator
-apiVersion: populator.storage.k8s.io/v1alpha1
+apiVersion: populator.storage.k8s.io/v1beta1
 metadata:
   name: hello-populator
 sourceKind:


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
For compatibility with the beta version of volume-data-source-validator, switch to the v1beta1 API

**Does this PR introduce a user-facing change?**:
```release-note
The example "hello" populator is updated for compatibility with v1.0 of volume-data-source-validator and its v1beta1 API.
```
