### PR TITLE
Rename hello.k8s.io to hello.example.com

### DIFF
--- a/example/hello-populator/README.md
+++ b/example/hello-populator/README.md
@@ -20,7 +20,7 @@ Create a CR:
 
 ```
 kubectl create -f - << EOF
-apiVersion: hello.k8s.io/v1alpha1
+apiVersion: hello.example.com/v1alpha1
 kind: Hello
 metadata:
   name: hello1
@@ -44,8 +44,8 @@ spec:
   resources:
     requests:
       storage: 10Mi
-  dataSource:
-    apiGroup: hello.k8s.io
+  dataSourceRef:
+    apiGroup: hello.example.com
     kind: Hello
     name: hello1
 EOF

--- a/example/hello-populator/crd.yaml
+++ b/example/hello-populator/crd.yaml
@@ -1,11 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: hellos.hello.k8s.io
-  annotations:
-    api-approved.kubernetes.io: unapproved
+  name: hellos.hello.example.com
 spec:
-  group: hello.k8s.io
+  group: hello.example.com
   names:
     kind: Hello
     listKind: HelloList

--- a/example/hello-populator/deploy.yaml
+++ b/example/hello-populator/deploy.yaml
@@ -27,7 +27,7 @@ rules:
     resources: [storageclasses]
     verbs: [get, list, watch]
 
-  - apiGroups: [hello.k8s.io]
+  - apiGroups: [hello.example.com]
     resources: [hellos]
     verbs: [get, list, watch]
 ---
@@ -61,11 +61,11 @@ spec:
       serviceAccount: hello-account
       containers:
         - name: hello
-          image: k8s.gcr.io/sig-storage/hello-populator:v0.1.0
+          image: k8s.gcr.io/sig-storage/hello-populator:v1.0.0
           imagePullPolicy: IfNotPresent
           args:
             - --mode=controller
-            - --image-name=k8s.gcr.io/sig-storage/hello-populator:v0.1.0
+            - --image-name=k8s.gcr.io/sig-storage/hello-populator:v1.0.0
             - --http-endpoint=:8080
           ports:
             - containerPort: 8080
@@ -77,5 +77,5 @@ apiVersion: populator.storage.k8s.io/v1beta1
 metadata:
   name: hello-populator
 sourceKind:
-  group: hello.k8s.io
+  group: hello.example.com
   kind: Hello

--- a/example/hello-populator/main.go
+++ b/example/hello-populator/main.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	prefix     = "hello.k8s.io"
+	prefix     = "hello.example.com"
 	mountPath  = "/mnt"
 	devicePath = "/dev/block"
 )
@@ -77,7 +77,7 @@ func main() {
 	switch mode {
 	case "controller":
 		const (
-			groupName  = "hello.k8s.io"
+			groupName  = "hello.example.com"
 			apiVersion = "v1alpha1"
 			kind       = "Hello"
 			resource   = "hellos"


### PR DESCRIPTION
**What type of PR is this?**
 /kind cleanup

**What this PR does / why we need it**:
This PR renames hello.k8s.io to hello.example.com. This change is needed to follow [the rule](https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/2337-k8s.io-group-protection#proposal) of API groups naming for CRDs.

**Which issue(s) this PR fixes**:
Fixes #22

**Special notes for your reviewer**:
xref: https://github.com/kubernetes/kubernetes/pull/108664#discussion_r840877623

@bswartz 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
hello-populator: Rename API groups of hello CRD from hello.k8s.io to hello.example.com.
```
