### PR TITLE
Replace k8s.gcr.io with registry.k8s.io

### DIFF
--- a/example/hello-populator/deploy.yaml
+++ b/example/hello-populator/deploy.yaml
@@ -61,11 +61,11 @@ spec:
       serviceAccount: hello-account
       containers:
         - name: hello
-          image: k8s.gcr.io/sig-storage/hello-populator:v1.0.1
+          image: registry.k8s.io/sig-storage/hello-populator:v1.0.1
           imagePullPolicy: IfNotPresent
           args:
             - --mode=controller
-            - --image-name=k8s.gcr.io/sig-storage/hello-populator:v1.0.1
+            - --image-name=registry.k8s.io/sig-storage/hello-populator:v1.0.1
             - --http-endpoint=:8080
           ports:
             - containerPort: 8080


### PR DESCRIPTION
Refer# https://github.com/kubernetes/k8s.io/wiki/New-Registry-url-for-Kubernetes-(registry.k8s.io)

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

> /kind cleanup

```release-note
NONE
```