### PR TITLE
Add klog cmdline parameters to sample populator

### DIFF
--- a/example/hello-populator/main.go
+++ b/example/hello-populator/main.go
@@ -52,6 +52,7 @@ func main() {
 		showVersion  bool
 		namespace    string
 	)
+	klog.InitFlags(nil)
 	// Main arg
 	flag.StringVar(&mode, "mode", "", "Mode to run in (controller, populate)")
 	// Populate args


### PR DESCRIPTION
hello-populator now accepts usual klog cmdline parameters like "-v 2".

/kind cleanup
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
