### PR TITLE
Add service account to the populator pod

### DIFF
--- a/example/hello-populator/main.go
+++ b/example/hello-populator/main.go
@@ -41,16 +41,17 @@ var version = "unknown"
 
 func main() {
 	var (
-		mode         string
-		fileName     string
-		fileContents string
-		httpEndpoint string
-		metricsPath  string
-		masterURL    string
-		kubeconfig   string
-		imageName    string
-		showVersion  bool
-		namespace    string
+		mode               string
+		fileName           string
+		fileContents       string
+		httpEndpoint       string
+		metricsPath        string
+		masterURL          string
+		kubeconfig         string
+		imageName          string
+		showVersion        bool
+		namespace          string
+		serviceaccountName string
 	)
 	klog.InitFlags(nil)
 	// Main arg
@@ -68,6 +69,7 @@ func main() {
 	// Other args
 	flag.BoolVar(&showVersion, "version", false, "display the version string")
 	flag.StringVar(&namespace, "namespace", "hello", "Namespace to deploy controller")
+	flag.StringVar(&serviceaccountName, "serviceaccountName", "default", "Service account name used by the populator.")
 	flag.Parse()
 
 	if showVersion {
@@ -88,7 +90,7 @@ func main() {
 			gvr = schema.GroupVersionResource{Group: groupName, Version: apiVersion, Resource: resource}
 		)
 		populator_machinery.RunController(masterURL, kubeconfig, imageName, httpEndpoint, metricsPath,
-			namespace, prefix, gk, gvr, mountPath, devicePath, getPopulatorPodArgs)
+			namespace, prefix, gk, gvr, mountPath, devicePath, getPopulatorPodArgs, serviceaccountName)
 	case "populate":
 		populate(fileName, fileContents)
 	default:


### PR DESCRIPTION
**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:
In some cases, a user would wish to provide the service account to the populator pod. This may be useful if the volume populator is part of some other project and prevent the requirement of creating more service accounts.

**Special notes for your reviewer**:
Maybe it's better to leave it empty in the example (setting default service account name to `""`).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
