### PR TITLE
chore: remove refs to deprecated io/ioutil

### DIFF
--- a/populator-machinery/metrics_test.go
+++ b/populator-machinery/metrics_test.go
@@ -19,7 +19,6 @@ package populator_machinery
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"reflect"
 	"sort"
@@ -142,7 +141,7 @@ func verifyInFlightMetric(expected string, srvAddr string) error {
 	if rsp.StatusCode != http.StatusOK {
 		return fmt.Errorf("failed to get response from serve: %s", http.StatusText(rsp.StatusCode))
 	}
-	r, err := ioutil.ReadAll(rsp.Body)
+	r, err := io.ReadAll(rsp.Body)
 	if err != nil {
 		return err
 	}
@@ -162,7 +161,7 @@ func verifyMetric(expected, srvAddr string) error {
 	if rsp.StatusCode != http.StatusOK {
 		return fmt.Errorf("failed to get response from serve: %s", http.StatusText(rsp.StatusCode))
 	}
-	r, err := ioutil.ReadAll(rsp.Body)
+	r, err := io.ReadAll(rsp.Body)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind cleanup


**What this PR does / why we need it**:
"io/ioutil" has been deprecated since Go 1.19: As of Go 1.16
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
