### PR TITLE
Use protobuf encoding for core K8s APIs in lib-volume-populator

### DIFF
--- a/populator-machinery/controller.go
+++ b/populator-machinery/controller.go
@@ -32,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/json"
@@ -46,6 +47,7 @@ import (
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	storagelisters "k8s.io/client-go/listers/storage/v1"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/record"
@@ -232,7 +234,9 @@ func RunControllerWithConfig(vpcfg VolumePopulatorConfig) {
 		klog.Fatalf("Failed to create config: %v", err)
 	}
 
-	kubeClient, err := kubernetes.NewForConfig(cfg)
+	coreCfg := rest.CopyConfig(cfg)
+	coreCfg.ContentType = runtime.ContentTypeProtobuf
+	kubeClient, err := kubernetes.NewForConfig(coreCfg)
 	if err != nil {
 		klog.Fatalf("Failed to create client: %v", err)
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
If not specified explicitly, JSON encoding is used by default when talking to kube-apiserver.

For core K8s API objects like Pods, Nodes, etc., we can use protobuf encoding which reduces CPU consumption related to (de)serialization, reduces overall latency of the API call, reduces memory footprint, reduces the amount of work performed by the GC and results in quicker propagation of objects to event handlers of shared informers.

For CRDs, however, we still have to stick to JSON since they do not support protobuf encoding.

**Which issue(s) this PR fixes**:
No issue is opened for that.

**Special notes for your reviewer**:
Standard system components of K8s default their serialization method to protobuf for some time already:
- `kube-scheduler`: [link](https://github.com/kubernetes/kubernetes/blob/d62b797c16fdffa55a8e2fc95f04bf72c019be70/pkg/scheduler/apis/config/v1/defaults.go#L143-L145)
- `kubelet`: [link](https://github.com/kubernetes/kubernetes/blob/d62b797c16fdffa55a8e2fc95f04bf72c019be70/pkg/kubelet/apis/config/v1beta1/defaults.go#L199-L201)
- `kube-proxy`: [link](https://github.com/kubernetes/kubernetes/blob/d62b797c16fdffa55a8e2fc95f04bf72c019be70/pkg/proxy/apis/config/v1alpha1/defaults.go#L126-L128)
- `kube-controller-manager`: [link](https://github.com/kubernetes/kubernetes/blob/d62b797c16fdffa55a8e2fc95f04bf72c019be70/staging/src/k8s.io/controller-manager/config/v1alpha1/defaults.go#L49) and [method's contents](https://github.com/kubernetes/kubernetes/blob/d62b797c16fdffa55a8e2fc95f04bf72c019be70/staging/src/k8s.io/component-base/config/v1alpha1/defaults.go#L66-L68)

Some benchmarks comparing JSON vs. protobuf showcasing how the latter data format (de)serializes faster and uses less memory:
- https://medium.com/@akresling/go-benchmark-json-v-protobuf-4ec3c62ec8d4
- https://www.codingexplorations.com/blog/performance-comparison-protobuf-marshaling-vs-json-marshaling-in-go
- https://medium.com/@david_turner/protocol-buffers-just-how-fast-are-they-9ec19ea580db

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```