### PR TITLE
Add mutator functions to allow modify the Kubernetes resources used b…

### DIFF
--- a/populator-machinery/controller.go
+++ b/populator-machinery/controller.go
@@ -78,7 +78,8 @@ const (
 	reasonPopulateOperationStartSuccess = "PopulateOperationStartSuccess"
 	reasonPopulateOperationFailed       = "PopulateOperationFailed"
 	reasonPopulateOperationFinished     = "PopulateOperationFinished"
-	reasonPVCCreationError              = "PopulatorPVCPrimeCreationError"
+	reasonPVCPrimeCreationError         = "PopulatorPVCPrimeCreationError"
+	reasonPVCPrimeMutatorError          = "reasonPVCPrimeMutatorError"
 	reasonWaitForDataPopulationFinished = "PopulatorWaitForDataPopulationFinished"
 	reasonStorageClassCreationError     = "PopulatorStorageClassCreationError"
 	reasonDataSourceNotFound            = "PopulatorDataSourceNotFound"
@@ -116,6 +117,7 @@ type controller struct {
 	referenceGrantSynced   cache.InformerSynced
 	podConfig              *PodConfig
 	providerFunctionConfig *ProviderFunctionConfig
+	mutatorConfig          *MutatorConfig
 	crossNamespace         bool
 	providerMetricManager  *ProviderMetricManager
 }
@@ -140,6 +142,9 @@ type VolumePopulatorConfig struct {
 	// ProviderFunctionConfig is the configuration for invoking provider functions. Either PodConfig or ProviderFunctionConfig should
 	// be specified. PodConfig and ProviderFunctionConfig can't be provided at the same time
 	ProviderFunctionConfig *ProviderFunctionConfig
+	// MutatorConfig is the configuration for invoking mutator functions. You can specify your own mutator functions to modify the
+	// Kubernetes resources used for volume population
+	MutatorConfig *MutatorConfig
 	// ProviderMetricManager is the manager for provider specific metric handling
 	ProviderMetricManager *ProviderMetricManager
 	// CrossNamespace indicates if the populator supports data sources located in namespaces different than the PVC's namespace.
@@ -187,6 +192,19 @@ type PopulatorParams struct {
 	// Unstructured is the CR data source created by user
 	Unstructured *unstructured.Unstructured
 	Recorder     record.EventRecorder
+}
+
+type MutatorConfig struct {
+	// PvcPrimeMutator is the mutator function for pvcPrime. The function gets called to modify the PVC object before pvcPrime gets created.
+	PvcPrimeMutator func(PvcPrimeMutatorParams) (*corev1.PersistentVolumeClaim, error)
+}
+
+// PvcPrimeMutatorParams includes the parameters passing to the PvcPrimeMutator function
+type PvcPrimeMutatorParams struct {
+	// PvcPrime is the temporary PVC created by volume populator
+	PvcPrime *corev1.PersistentVolumeClaim
+	// StorageClass is the original StorageClass Pvc refer to
+	StorageClass *storagev1.StorageClass
 }
 
 func RunController(masterURL, kubeconfig, imageName, httpEndpoint, metricsPath, namespace, prefix string,
@@ -292,6 +310,7 @@ func RunControllerWithConfig(vpcfg VolumePopulatorConfig) {
 		referenceGrantSynced:   referenceGrants.Informer().HasSynced,
 		podConfig:              vpcfg.PodConfig,
 		providerFunctionConfig: vpcfg.ProviderFunctionConfig,
+		mutatorConfig:          vpcfg.MutatorConfig,
 		crossNamespace:         vpcfg.CrossNamespace,
 		providerMetricManager:  vpcfg.ProviderMetricManager,
 	}
@@ -701,9 +720,24 @@ func (c *controller) syncPvc(ctx context.Context, key, pvcNamespace, pvcName str
 				annSelectedNode: nodeName,
 			}
 		}
+		if c.mutatorConfig != nil && c.mutatorConfig.PvcPrimeMutator != nil {
+			mp := PvcPrimeMutatorParams{
+				PvcPrime:     pvcPrime,
+				StorageClass: storageClass,
+			}
+			pvcPrime, err = c.mutatorConfig.PvcPrimeMutator(mp)
+			if err != nil {
+				c.recorder.Eventf(pvc, corev1.EventTypeWarning, reasonPVCPrimeMutatorError, "Failed to mutate populator pvcPrime: %s", err)
+				return err
+			}
+			if pvcPrime == nil {
+				c.recorder.Eventf(pvc, corev1.EventTypeWarning, reasonPVCPrimeMutatorError, "pvcPrime must not be nil")
+				return fmt.Errorf("pvcPrime must not be nil")
+			}
+		}
 		pvcPrime, err = c.kubeClient.CoreV1().PersistentVolumeClaims(c.populatorNamespace).Create(ctx, pvcPrime, metav1.CreateOptions{})
 		if err != nil {
-			c.recorder.Eventf(pvc, corev1.EventTypeWarning, reasonPVCCreationError, "Failed to create populator PVC prime: %s", err)
+			c.recorder.Eventf(pvc, corev1.EventTypeWarning, reasonPVCPrimeCreationError, "Failed to create populator pvcPrime: %s", err)
 			return err
 		}
 	}
@@ -734,7 +768,7 @@ func (c *controller) syncPvc(ctx context.Context, key, pvcNamespace, pvcName str
 			if c.providerFunctionConfig.PopulateFn != nil {
 
 				if "" == pvcPrime.Spec.VolumeName {
-					// We'll get called again later when the pvc prime gets bounded
+					// We'll get called again later when the pvcPrime gets bounded
 					return nil
 				}
 				pv, err := params.KubeClient.CoreV1().PersistentVolumes().Get(ctx, pvcPrime.Spec.VolumeName, metav1.GetOptions{})


### PR DESCRIPTION
…y volume population

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
In some cases we might want to customize the default Kubernetes objects in volume populator, so add plugin functions to allow modification for the objects.
 
* Add MutatorConfig to Volume Populator Controller to allow specify mutator functions to modify the Kubernetes resources used by volume populator
* Add the PvcPrimeMutator to allow modify PVC prime before object creation

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add MutatorConfig to Volume Populator Controller to allow specify mutator functions to modify the Kubernetes resources used for volume population. Add the PvcPrimeMutator function to allow modify PVC prime before object creation

```
