### PR TITLE
Fix make test failure at local run

### DIFF
--- a/populator-machinery/controller_test.go
+++ b/populator-machinery/controller_test.go
@@ -349,7 +349,7 @@ func runSyncPvcTests(tests []testCase, t *testing.T) {
 			}
 			err := compareNotifyMap(test.expectedKeys, c.notifyMap)
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Errorf("%v", err.Error())
 			}
 		})
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
"make test" failed locally with error:

```
populator-machinery/controller_test.go:352:14: non-constant format string in call to (*testing.common).Errorf
```

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
