### PR TITLE
Trigger upstream test run for GA

### DIFF
--- a/populator-machinery/controller_test.go
+++ b/populator-machinery/controller_test.go
@@ -399,6 +399,7 @@ func runSyncPvcTests(tests []testCase, t *testing.T) {
 			actualPvcPrime, err := c.kubeClient.CoreV1().PersistentVolumeClaims(testVpWorkingNamespace).Get(context.TODO(), testPvcPrimeName, metav1.GetOptions{})
 			if err != nil {
 				if !errors.IsNotFound(err) {
+					// Trigger tests upstream
 					t.Errorf("Get pvcPrime failed, error: %+v", err.Error())
 				}
 			}


### PR DESCRIPTION
Just to trigger test run in the dashboard

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
