### PR TITLE
Clean up provider specfic code, remove provider related logic

### DIFF
--- a/populator-machinery/controller.go
+++ b/populator-machinery/controller.go
@@ -185,8 +185,6 @@ type PopulatorParams struct {
 	Pvc *corev1.PersistentVolumeClaim
 	// PvcPrime is the temporary PVC created by volume populator
 	PvcPrime *corev1.PersistentVolumeClaim
-	// PV refers to the storage instance where data will be transferred, and it will be bound to the original PVC when the data transfer is complete
-	PV *corev1.PersistentVolume
 	// StorageClass is the original StorageClass Pvc refer to
 	StorageClass *storagev1.StorageClass
 	// Unstructured is the CR data source created by user
@@ -776,11 +774,6 @@ func (c *controller) syncPvc(ctx context.Context, key, pvcNamespace, pvcName str
 						// We'll get called again later when the pvcPrime gets bounded
 						return nil
 					}
-					pv, err := params.KubeClient.CoreV1().PersistentVolumes().Get(ctx, pvcPrime.Spec.VolumeName, metav1.GetOptions{})
-					if err != nil {
-						return err
-					}
-					params.PV = pv
 
 					err = c.providerFunctionConfig.PopulateFn(ctx, *params)
 					if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
The piece of code should be implemented within the `c.providerFunctionConfig.PopulateFn` as needed

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Remove PV from the `PopulatorParams` API
```
