### PR TITLE
fix: go module name convention

### DIFF
--- a/example/hello-populator/main.go
+++ b/example/hello-populator/main.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
 
-	populator_machinery "github.com/kubernetes-csi/lib-volume-populator/populator-machinery"
+	populator_machinery "github.com/kubernetes-csi/lib-volume-populator/v2/populator-machinery"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kubernetes-csi/lib-volume-populator
+module github.com/kubernetes-csi/lib-volume-populator/v2
 
 go 1.19
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Update the module name in the `v2` release to follow the Go Module naming convention, see also #225

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
I've created this PR as the version of Go in the `v3` module release is incompatible with CAPI.

**Does this PR introduce a user-facing change?**:
```release-note
Fixed the module name so that it can import the v2 module version. You can now import the v2.0 module with 'import "github.com/kubernetes-csi/lib-volume-populator/v2"'
```