### PR TITLE
Fix go module name convention in v2

### DIFF
--- a/example/hello-populator/main.go
+++ b/example/hello-populator/main.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
 
-	populator_machinery "github.com/kubernetes-csi/lib-volume-populator/populator-machinery"
+	populator_machinery "github.com/kubernetes-csi/lib-volume-populator/v2/populator-machinery"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kubernetes-csi/lib-volume-populator
+module github.com/kubernetes-csi/lib-volume-populator/v2
 
 go 1.19
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Previous tentative fix failed the tests in https://github.com/kubernetes-csi/lib-volume-populator/pull/229, trying again.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Fix go module name convention in v2
```
